### PR TITLE
change enter/exit_tree to enable/disable_plugin

### DIFF
--- a/addons/modular-settings-menu/plugin.gd
+++ b/addons/modular-settings-menu/plugin.gd
@@ -5,9 +5,9 @@ var pluginPath: String = get_script().resource_path.get_base_dir()
 const settingsDataManagerPath: String = "/singletons/settings_data_manager.gd"
 
 
-func _enter_tree():
+func _enable_plugin():
 	add_autoload_singleton("SettingsDataManager", pluginPath + settingsDataManagerPath)
 
 
-func _exit_tree():
+func _disable_plugin():
 	remove_autoload_singleton("SettingsDataManager")


### PR DESCRIPTION
Using `add_autoload_singleton` on `_enter_tree` puts the godot project on an unsaved changes state, changing to `_enable_plugin` instead eliminates this problem